### PR TITLE
fix: improve blog-interactive responsive layout

### DIFF
--- a/blog-interactive/css/style.css
+++ b/blog-interactive/css/style.css
@@ -136,6 +136,7 @@ a:hover {
     width: 55%;
     height: 100vh;
     z-index: 1;
+    overflow: hidden;
 }
 
 #map {
@@ -492,7 +493,25 @@ a:hover {
     box-shadow: 0 2px 20px rgba(0, 0, 0, 0.08);
     border-left: 4px solid #1b3a4b;
     max-width: 520px;
+    position: relative;
     transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.step-content-wrapper {
+    position: relative;
+}
+
+.step-content-wrapper.has-overflow::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3rem;
+    background: linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.97) 100%);
+    border-radius: 0 0 8px 8px;
+    pointer-events: none;
+    z-index: 2;
 }
 
 .step.is-active .step-content {
@@ -703,7 +722,14 @@ a:hover {
 
     .step-content {
         max-width: 100%;
+        max-height: calc(44vh - 2rem);
+        overflow-y: auto;
         padding: 1.25rem;
+    }
+
+    .step:not(.is-active) .step-content {
+        opacity: 0;
+        pointer-events: none;
     }
 
     /* Scale down media panels in stacked mode */

--- a/blog-interactive/css/style.css
+++ b/blog-interactive/css/style.css
@@ -678,7 +678,7 @@ a:hover {
 
     #map-container {
         width: 100%;
-        height: 50vh;
+        height: 55vh;
         position: sticky;
         top: 0;
     }
@@ -689,13 +689,21 @@ a:hover {
     }
 
     .step {
-        min-height: 60vh;
+        min-height: 40vh;
         padding: 1.5rem 1rem;
+    }
+
+    .step:first-child {
+        padding-top: 5vh;
+    }
+
+    .step:last-child {
+        padding-bottom: 20vh;
     }
 
     .step-content {
         max-width: 100%;
-        padding: 1.5rem;
+        padding: 1.25rem;
     }
 
     /* Scale down media panels in stacked mode */

--- a/blog-interactive/css/style.css
+++ b/blog-interactive/css/style.css
@@ -700,6 +700,11 @@ a:hover {
         height: 55vh;
         position: sticky;
         top: 0;
+        z-index: 10;
+    }
+
+    .story {
+        z-index: 1;
     }
 
     .story {

--- a/blog-interactive/css/style.css
+++ b/blog-interactive/css/style.css
@@ -644,6 +644,33 @@ a:hover {
 }
 
 /* ===== Responsive ===== */
+
+/* Tablet landscape / narrow desktop: tighten the side-by-side layout */
+@media (max-width: 1200px) {
+    #map-container {
+        width: 50%;
+    }
+
+    .story {
+        width: 50%;
+    }
+
+    .step-content {
+        max-width: 100%;
+        padding: 1.75rem 2rem;
+    }
+
+    .step-content h2 {
+        font-size: 1.3rem;
+    }
+
+    .step-content p,
+    .step-content ul {
+        font-size: 0.9rem;
+    }
+}
+
+/* Tablet portrait / phablet: switch to stacked layout */
 @media (max-width: 900px) {
     #scrolly {
         flex-direction: column;
@@ -669,5 +696,63 @@ a:hover {
     .step-content {
         max-width: 100%;
         padding: 1.5rem;
+    }
+
+    /* Scale down media panels in stacked mode */
+    .environment-media-figure,
+    .after-ban-media-figure,
+    .conclusion-media-figure {
+        width: 100%;
+    }
+
+    .environment-media-figure img,
+    .after-ban-media-figure img,
+    .conclusion-slideshow {
+        height: 42vh;
+        max-height: none;
+    }
+
+    .conclusion-media-figure img {
+        position: relative;
+        inset: auto;
+        height: 42vh;
+    }
+}
+
+/* Mobile: tighten further */
+@media (max-width: 600px) {
+    .site-title {
+        font-size: 1.6rem;
+    }
+
+    .site-subtitle {
+        font-size: 0.95rem;
+    }
+
+    #map-container {
+        height: 45vh;
+    }
+
+    .step {
+        min-height: 50vh;
+        padding: 1.25rem 0.75rem;
+    }
+
+    .step-content {
+        padding: 1.25rem;
+        border-left-width: 3px;
+    }
+
+    .step-content h2 {
+        font-size: 1.2rem;
+    }
+
+    .step-content p,
+    .step-content ul {
+        font-size: 0.875rem;
+    }
+
+    .byline {
+        font-size: 0.8rem;
     }
 }

--- a/blog-interactive/index.html
+++ b/blog-interactive/index.html
@@ -200,7 +200,7 @@
         <div class="footer-content">
             <p>Built with <a href="https://leafletjs.com" target="_blank">Leaflet</a> · Data from USDA NAIP, CAL FIRE, &amp; Calaveras County Public Records</p>
             <p><a href="https://github.com/wxmiked/cannabis-deforestation" target="_blank">View source on GitHub</a></p>
-            <p>© 2025 Mike Dvorak</p>
+            <p>© 2026 Mike Dvorak</p>
         </div>
     </footer>
 

--- a/blog-interactive/index.html
+++ b/blog-interactive/index.html
@@ -205,6 +205,6 @@
     </footer>
 
     <script src="js/county_boundary.js?v=8"></script>
-    <script src="js/app.js?v=8"></script>
+    <script src="js/app.js?v=9"></script>
 </body>
 </html>

--- a/blog-interactive/index.html
+++ b/blog-interactive/index.html
@@ -17,7 +17,7 @@
     <script src="https://unpkg.com/intersection-observer@0.12.2/intersection-observer.js"></script>
 
     <!-- Custom styles -->
-    <link rel="stylesheet" href="css/style.css?v=8" />
+    <link rel="stylesheet" href="css/style.css?v=9" />
 
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/blog-interactive/index.html
+++ b/blog-interactive/index.html
@@ -87,37 +87,37 @@
 
                 <!-- SECTION 1: Introduction -->
                 <div class="step" data-step="intro" data-center="38.19,-120.65" data-zoom="10" data-layers="county-boundary">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>Calaveras County, California</h2>
                         <p>Nestled in the Sierra Nevada foothills, Calaveras County is known for its Gold Rush history, giant sequoias, and Mark Twain's celebrated jumping frog. But starting in 2016, it became the center of a different kind of story.</p>
                         <p>When California legalized recreational cannabis with <strong>Proposition 64</strong>, Calaveras County introduced an Urgency Ordinance to regulate and tax cultivation — setting off a land rush that would transform the county's landscape.</p>
-                    </div>
+                    </div></div>
                 </div>
 
                 <!-- SECTION 2: Before -->
                 <div class="step" data-step="before-2014" data-center="38.19,-120.55" data-zoom="13" data-layers="naip-2014,naip-2016,parcels,butte-fire" data-compare="true" data-compare-left="naip-2014" data-compare-right="naip-2016" data-compare-left-label="Pre-fire (2014)" data-compare-right-label="Post-fire (2016)">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>2015 Butte Fire: Creates the Opportunity</h2>
                         <p>In September 2015, the Butte Fire burned across Amador and Calaveras counties. The perimeter shown here traces the same burn scar that later intersected many parcels tied to cultivation activity.</p>
                         <p>Use the slider to compare <strong>2014 (left)</strong> and <strong>2016 (right)</strong>. Before the fire, much of this landscape was dense foothill forest; by 2016, newly disturbed ground and access routes are visibly more extensive.</p>
                         <p>As described in the project narrative, the burn scar and post-fire disruption also made some rural parcels more financially accessible, creating conditions that accelerated speculative cultivation activity before county enforcement caught up.</p>
                         <p class="data-note">🟧 Orange fill shows the 2015 Butte Fire perimeter (~70,846 GIS acres), about <strong>11%</strong> of Calaveras County's total area (~1,037 square miles). 🟦 Blue outlines show the 712 parcels that applied for cultivation permits under Calaveras County's <strong>2016 Urgency Ordinance</strong>.</p>
-                    </div>
+                    </div></div>
                 </div>
 
                 <!-- SECTION 3: Peak Cultivation -->
                 <div class="step" data-step="peak-2016" data-center="38.19,-120.55" data-zoom="13" data-layers="naip-2016,parcels">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>The Boom: 2016</h2>
                         <p>By 2016, the impact is unmistakable. NAIP imagery reveals <strong>widespread clearing</strong> within cannabis-permitted parcels — bare earth, access roads, hoop houses, and cultivation rows.</p>
                         <p>The county's Urgency Ordinance required applicants to already be growing cannabis before applying, which <strong>incentivized rapid clearing</strong> of forested land to establish operations before the permit deadline.</p>
                         <p>At the peak, the county cannabis registry captured <strong>1,015 records</strong>; some entries did not include <strong>parcel numbers</strong> because they were protected medical cannabis permits.</p>
-                    </div>
+                    </div></div>
                 </div>
 
                 <!-- SECTION 4: After the Ban -->
                 <div class="step" data-step="after-2018" data-center="38.19,-120.55" data-zoom="13" data-layers="naip-2018,parcels">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>After the Ban: 2018</h2>
                         <p>In 2018, the Board of Supervisors <strong>banned all commercial cannabis cultivation</strong>, making previously permitted sites illegal. The 2018 NAIP imagery tells a mixed story:</p>
                         <ul>
@@ -127,32 +127,32 @@
                         </ul>
                         <p>Today, even where some of these scars are partially hidden by new vegetation, the underlying disturbance remains.</p>
                         <p>By 2022, only <strong>65 licensed cultivation sites</strong> remained, while unpermitted activity continued at a wider scale, as documented in the <strong>2023 Calaveras County Civil Grand Jury Report</strong>.</p>
-                    </div>
+                    </div></div>
                 </div>
 
                 <!-- SECTION 6: The Data -->
                 <div class="step" data-step="data" data-center="38.19,-120.55" data-zoom="12" data-layers="parcels,detections">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>Mapping the Invisible</h2>
                         <p>This map was built using data that was never meant to be a map. Through a <strong>California Public Records Act</strong> request, we obtained the Calaveras County Planning Department's cannabis permit registry under the 2016 Urgency Ordinance, including records with public parcel numbers.</p>
                         <p>We extracted <strong>712 parcel numbers</strong> from the PDF using text processing, then joined them against the county's GIS parcel boundaries to create a spatial dataset of cannabis cultivation sites.</p>
                         <p class="data-note">🔴 Red polygons show 2016 detected cannabis farms, identified via ML semantic segmentation of NAIP imagery.</p>
-                    </div>
+                    </div></div>
                 </div>
 
                 <!-- SECTION 7: ML Detection -->
                 <div class="step" data-step="ml" data-center="38.34,-120.52" data-zoom="14" data-layers="naip-2016,detections">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>Teaching Machines to See Cannabis Farms</h2>
                         <p>We trained a <strong>semantic segmentation model</strong> (U-Net with ResNet-50 backbone) on manually annotated 2016 NAIP imagery to detect cannabis cultivation sites from aerial imagery.</p>
                         <p>The <strong>red polygons</strong> on the map are 2016 detected cannabis farms. The model identifies characteristic patterns: cleared forest patches, organized rows, hoop house structures, and access roads within the parcels.</p>
                         <p>Current limitations include false positives on vineyards and orchards. Multi-temporal training across 2014, 2016, and 2018 is a next step.</p>
-                    </div>
+                    </div></div>
                 </div>
 
                 <!-- SECTION 8: Environmental Impact -->
                 <div class="step" data-step="environment" data-center="38.19,-120.55" data-zoom="11" data-layers="parcels">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>Environmental Impact</h2>
                         <p>According to the <strong>2023 Calaveras County Civil Grand Jury Report</strong>, illegal cannabis cultivation has significantly impacted the environment:</p>
                         <ul>
@@ -162,12 +162,12 @@
                             <li><strong>Habitat fragmentation</strong> affecting wildlife corridors</li>
                         </ul>
                         <p>Environmental damage often went unaddressed due to limited coordination among county agencies, insufficient resources, and weak penalties.</p>
-                    </div>
+                    </div></div>
                 </div>
 
                 <!-- SECTION 9: Methodology -->
                 <div class="step" data-step="methodology" data-center="38.19,-120.55" data-zoom="11" data-layers="parcels">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>How This Was Made</h2>
                         <p><strong>Data sources:</strong></p>
                         <ul>
@@ -178,17 +178,17 @@
                         </ul>
                         <p><strong>Tools:</strong> Python, GDAL, Leaflet.js, TorchGeo, LabelMe</p>
                         <p><strong>Code:</strong> <a href="https://github.com/wxmiked/cannabis-deforestation" target="_blank">github.com/wxmiked/cannabis-deforestation</a></p>
-                    </div>
+                    </div></div>
                 </div>
 
                 <!-- SECTION 10: Conclusion -->
                 <div class="step" data-step="conclusion" data-center="38.19,-120.65" data-zoom="10" data-layers="parcels">
-                    <div class="step-content">
+                    <div class="step-content-wrapper"><div class="step-content">
                         <h2>Looking Forward</h2>
                         <p>Calaveras County's cannabis story is a cautionary tale about the unintended consequences of rapid legalization without adequate environmental safeguards.</p>
                         <p>Aerial imagery provides a powerful, objective record of land use change that persists long after political debates have moved on. By combining public records with remote sensing, we can quantify environmental impacts that might otherwise go unmeasured.</p>
                         <p>This project is ongoing. We plan to extend the analysis to additional years and neighboring counties.</p>
-                    </div>
+                    </div></div>
                 </div>
 
             </div><!-- .story -->

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -699,7 +699,7 @@
         // Reset clip on all NAIP panes
         ['naip-2014', 'naip-2016', 'naip-2018'].forEach(function (paneName) {
             var pane = map.getPane(paneName);
-            if (pane) { pane.style.clip = ''; pane.style.clipPath = ''; }
+            if (pane) { pane.style.clipPath = ''; }
         });
     }
 
@@ -749,20 +749,24 @@
             var h = mapRect.height;
             var splitX = Math.round(w * sliderPos);
 
-            // Compute clip in pane-local coords by compensating for pane transform
-            // Use clip-path: inset() — modern, Firefox-compatible replacement for
-            // the deprecated clip: rect() which Firefox has dropped.
+            // Use clip-path: polygon() with percentage values.
+            // Percentages are relative to the element's own dimensions (pre-transform),
+            // so this works correctly regardless of Leaflet's CSS transform offsets.
+            // clip: rect() was deprecated and dropped by Firefox; inset() has coordinate
+            // space issues with transformed elements.
             var leftRect = leftPane.getBoundingClientRect();
             var ldx = mapRect.left - leftRect.left;
-            var ldy = mapRect.top  - leftRect.top;
-            var leftRight = leftRect.width - (splitX + ldx);
-            leftPane.style.clipPath = 'inset(' + ldy + 'px ' + leftRight + 'px ' + '0px ' + ldx + 'px)';
+            var leftPct = leftRect.width > 0
+                ? Math.max(0, Math.min(100, (splitX + ldx) / leftRect.width * 100)).toFixed(2)
+                : '50.00';
+            leftPane.style.clipPath = 'polygon(0% 0%, ' + leftPct + '% 0%, ' + leftPct + '% 100%, 0% 100%)';
 
             var rightRect = rightPane.getBoundingClientRect();
             var rdx = mapRect.left - rightRect.left;
-            var rdy = mapRect.top  - rightRect.top;
-            var rightLeft = splitX + rdx;
-            rightPane.style.clipPath = 'inset(' + rdy + 'px 0px 0px ' + rightLeft + 'px)';
+            var rightPct = rightRect.width > 0
+                ? Math.max(0, Math.min(100, (splitX + rdx) / rightRect.width * 100)).toFixed(2)
+                : '50.00';
+            rightPane.style.clipPath = 'polygon(' + rightPct + '% 0%, 100% 0%, 100% 100%, ' + rightPct + '% 100%)';
 
             compareSliderEl.style.left = splitX + 'px';
         };

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -931,12 +931,33 @@
         });
     }
 
+    function initScrollOverflowIndicators() {
+        var contents = document.querySelectorAll('.step-content');
+        contents.forEach(function (el) {
+            // Wrap in a relative container so ::after can overlay the bottom
+            var wrapper = document.createElement('div');
+            wrapper.className = 'step-content-wrapper';
+            el.parentNode.insertBefore(wrapper, el);
+            wrapper.appendChild(el);
+
+            function update() {
+                var overflows = el.scrollHeight > el.clientHeight + 4;
+                var atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 8;
+                wrapper.classList.toggle('has-overflow', overflows && !atBottom);
+            }
+            update();
+            el.addEventListener('scroll', update);
+            window.addEventListener('resize', update);
+        });
+    }
+
     // ── Boot ──
     document.addEventListener('DOMContentLoaded', function () {
         resetScrollToStart();
         initMap();
         loadData();
         initScrollama();
+        initScrollOverflowIndicators();
     });
 
 })();

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -904,10 +904,15 @@
     function initScrollama() {
         var scroller = scrollama();
 
+        // On mobile (stacked layout), the map occupies the top ~55vh and story
+        // cards sit below it. Use a lower offset so steps trigger when the top
+        // of the card enters the viewport rather than waiting for the midpoint.
+        var scrollamaOffset = window.innerWidth <= 900 ? 0.85 : 0.5;
+
         scroller
             .setup({
                 step: '.step',
-                offset: 0.5,
+                offset: scrollamaOffset,
                 progress: false,
                 debug: false
             })

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -88,8 +88,7 @@
         color: '#ff8f00',
         weight: 3,
         opacity: 0.95,
-        fill: false,
-        interactive: false
+        fill: false
     };
 
     // ── Register a Planetary Computer mosaic for a given NAIP year ──

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -88,7 +88,8 @@
         color: '#ff8f00',
         weight: 3,
         opacity: 0.95,
-        fill: false
+        fill: false,
+        interactive: false
     };
 
     // ── Register a Planetary Computer mosaic for a given NAIP year ──
@@ -652,24 +653,29 @@
             return;
         }
 
-        // Add requested layers
+        // Add requested layers in a fixed z-order: NAIP tiles → county → butte fire → parcels → detections
+        // Butte fire must be below parcels so parcel popups are reachable (fire is non-interactive anyway).
         var activeYear = null;
+        var wantButte = layerNames.indexOf('butte-fire') !== -1;
+        var wantParcels = layerNames.indexOf('parcels') !== -1;
+        var wantDetections = layerNames.indexOf('detections') !== -1;
+
         layerNames.forEach(function (name) {
             if (name === 'county-boundary' && countyBoundaryLayer) {
                 countyBoundaryLayer.addTo(map);
-            } else if (name === 'parcels' && parcelsLayer) {
-                parcelsLayer.addTo(map);
-            } else if (name === 'detections') {
-                if (detectionsLayer) detectionsLayer.addTo(map);
-            } else if (name === 'butte-fire') {
-                if (butteFireLayer) butteFireLayer.addTo(map);
+            } else if (name === 'parcels' || name === 'detections' || name === 'butte-fire') {
+                // handled below in correct order
             } else if (layers[name]) {
                 layers[name].addTo(map);
-                // Track the year for the label
                 var match = name.match(/(\d{4})/);
                 if (match) activeYear = match[1];
             }
         });
+
+        // Add vector overlays in z-order: butte fire (bottom) → parcels → detections (top)
+        if (wantButte && butteFireLayer) butteFireLayer.addTo(map);
+        if (wantParcels && parcelsLayer) parcelsLayer.addTo(map);
+        if (wantDetections && detectionsLayer) detectionsLayer.addTo(map);
 
         if (countyBoundaryLayer && !map.hasLayer(countyBoundaryLayer)) {
             countyBoundaryLayer.addTo(map);

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -699,7 +699,7 @@
         // Reset clip on all NAIP panes
         ['naip-2014', 'naip-2016', 'naip-2018'].forEach(function (paneName) {
             var pane = map.getPane(paneName);
-            if (pane) pane.style.clip = '';
+            if (pane) { pane.style.clip = ''; pane.style.clipPath = ''; }
         });
     }
 
@@ -750,15 +750,19 @@
             var splitX = Math.round(w * sliderPos);
 
             // Compute clip in pane-local coords by compensating for pane transform
+            // Use clip-path: inset() — modern, Firefox-compatible replacement for
+            // the deprecated clip: rect() which Firefox has dropped.
             var leftRect = leftPane.getBoundingClientRect();
             var ldx = mapRect.left - leftRect.left;
             var ldy = mapRect.top  - leftRect.top;
-            leftPane.style.clip = 'rect(' + ldy + 'px, ' + (splitX + ldx) + 'px, ' + (h + ldy) + 'px, ' + ldx + 'px)';
+            var leftRight = leftRect.width - (splitX + ldx);
+            leftPane.style.clipPath = 'inset(' + ldy + 'px ' + leftRight + 'px ' + '0px ' + ldx + 'px)';
 
             var rightRect = rightPane.getBoundingClientRect();
             var rdx = mapRect.left - rightRect.left;
             var rdy = mapRect.top  - rightRect.top;
-            rightPane.style.clip = 'rect(' + rdy + 'px, ' + (w + rdx) + 'px, ' + (h + rdy) + 'px, ' + (splitX + rdx) + 'px)';
+            var rightLeft = splitX + rdx;
+            rightPane.style.clipPath = 'inset(' + rdy + 'px 0px 0px ' + rightLeft + 'px)';
 
             compareSliderEl.style.left = splitX + 'px';
         };

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -18,7 +18,8 @@
     var PARCEL_BBOX = [[-120.98,37.92],[-120.31,37.92],[-120.31,38.46],[-120.98,38.46],[-120.98,37.92]];
 
     var TILE_OPTIONS = {
-        minZoom: 11,
+        minZoom: 8,
+        minNativeZoom: 11,
         maxNativeZoom: 18,
         maxZoom: 20,
         tms: false,
@@ -890,41 +891,72 @@
             layerNames.indexOf('butte-fire') !== -1 &&
             butteFireLayer;
 
+        // Apply layers after map animation completes so Leaflet renders tiles correctly.
+        // Adding a tile layer mid-animation causes Leaflet to defer tile loading and
+        // never recover — tiles only load when the view is stable.
+        function applyLayers() {
+            setVisibleLayers(layerNames);
+            if (isCompare) {
+                enableCompare(compareLeft, compareRight, compareLeftLabel, compareRightLabel);
+            }
+        }
+
         if (shouldFitParcels) {
             var parcelsBounds = parcelsLayer.getBounds();
             if (parcelsBounds && parcelsBounds.isValid()) {
-                map.flyToBounds(parcelsBounds.pad(0.02), {
-                    duration: 1.2,
-                    maxZoom: targetZoom
-                });
+                var parcelsApplied = false;
                 map.once('moveend', function () {
+                    if (parcelsApplied) return;
+                    parcelsApplied = true;
                     logMapView('step:' + stepId + ':parcels-fit');
+                    applyLayers();
                 });
+                map.flyToBounds(parcelsBounds.pad(0.02), { duration: 1.2, maxZoom: targetZoom });
+                setTimeout(function () {
+                    if (parcelsApplied) return;
+                    parcelsApplied = true;
+                    applyLayers();
+                }, 1400);
+            } else {
+                applyLayers();
             }
         } else if (shouldFitButte) {
             var butteBounds = butteFireLayer.getBounds();
             if (butteBounds && butteBounds.isValid()) {
-                map.flyToBounds(butteBounds.pad(0.08), {
-                    duration: 1.2,
-                    maxZoom: targetZoom
-                });
+                var butteApplied = false;
                 map.once('moveend', function () {
+                    if (butteApplied) return;
+                    butteApplied = true;
                     logMapView('step:' + stepId + ':butte-fit');
+                    applyLayers();
                 });
+                map.flyToBounds(butteBounds.pad(0.08), { duration: 1.2, maxZoom: targetZoom });
+                setTimeout(function () {
+                    if (butteApplied) return;
+                    butteApplied = true;
+                    applyLayers();
+                }, 1400);
+            } else {
+                applyLayers();
             }
         } else if (targetCenter) {
-            map.flyTo(targetCenter, targetZoom, { duration: 1.2 });
+            // Guard: if map is already at target, flyTo may not fire moveend.
+            // Use a short timeout as fallback.
+            var layersApplied = false;
             map.once('moveend', function () {
+                if (layersApplied) return;
+                layersApplied = true;
                 logMapView('step:' + stepId);
+                applyLayers();
             });
-        }
-
-        // Parse and set layers
-        setVisibleLayers(layerNames);
-
-        // Enable compare mode if requested
-        if (isCompare) {
-            enableCompare(compareLeft, compareRight, compareLeftLabel, compareRightLabel);
+            map.flyTo(targetCenter, targetZoom, { duration: 1.2 });
+            setTimeout(function () {
+                if (layersApplied) return;
+                layersApplied = true;
+                applyLayers();
+            }, 1400);
+        } else {
+            applyLayers();
         }
     }
 

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -932,14 +932,10 @@
     }
 
     function initScrollOverflowIndicators() {
-        var contents = document.querySelectorAll('.step-content');
-        contents.forEach(function (el) {
-            // Wrap in a relative container so ::after can overlay the bottom
-            var wrapper = document.createElement('div');
-            wrapper.className = 'step-content-wrapper';
-            el.parentNode.insertBefore(wrapper, el);
-            wrapper.appendChild(el);
-
+        var wrappers = document.querySelectorAll('.step-content-wrapper');
+        wrappers.forEach(function (wrapper) {
+            var el = wrapper.querySelector('.step-content');
+            if (!el) return;
             function update() {
                 var overflows = el.scrollHeight > el.clientHeight + 4;
                 var atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 8;

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -700,7 +700,7 @@
         // Reset clip on all NAIP panes
         ['naip-2014', 'naip-2016', 'naip-2018'].forEach(function (paneName) {
             var pane = map.getPane(paneName);
-            if (pane) { pane.style.clipPath = ''; }
+            if (pane) { pane.style.clip = ''; pane.style.clipPath = ''; }
         });
     }
 
@@ -750,24 +750,19 @@
             var h = mapRect.height;
             var splitX = Math.round(w * sliderPos);
 
-            // Use clip-path: polygon() with percentage values.
-            // Percentages are relative to the element's own dimensions (pre-transform),
-            // so this works correctly regardless of Leaflet's CSS transform offsets.
-            // clip: rect() was deprecated and dropped by Firefox; inset() has coordinate
-            // space issues with transformed elements.
+            // clip: rect() works on position:absolute elements (which Leaflet panes are).
+            // We set both clip (legacy) and clip-path (modern) for maximum compatibility.
+            // clip-path: inset() and polygon() have coordinate-space issues with
+            // Leaflet's CSS transforms on pane elements.
             var leftRect = leftPane.getBoundingClientRect();
             var ldx = mapRect.left - leftRect.left;
-            var leftPct = leftRect.width > 0
-                ? Math.max(0, Math.min(100, (splitX + ldx) / leftRect.width * 100)).toFixed(2)
-                : '50.00';
-            leftPane.style.clipPath = 'polygon(0% 0%, ' + leftPct + '% 0%, ' + leftPct + '% 100%, 0% 100%)';
+            var ldy = mapRect.top  - leftRect.top;
+            leftPane.style.clip = 'rect(' + ldy + 'px, ' + (splitX + ldx) + 'px, ' + (h + ldy) + 'px, ' + ldx + 'px)';
 
             var rightRect = rightPane.getBoundingClientRect();
             var rdx = mapRect.left - rightRect.left;
-            var rightPct = rightRect.width > 0
-                ? Math.max(0, Math.min(100, (splitX + rdx) / rightRect.width * 100)).toFixed(2)
-                : '50.00';
-            rightPane.style.clipPath = 'polygon(' + rightPct + '% 0%, 100% 0%, 100% 100%, ' + rightPct + '% 100%)';
+            var rdy = mapRect.top  - rightRect.top;
+            rightPane.style.clip = 'rect(' + rdy + 'px, ' + (w + rdx) + 'px, ' + (h + rdy) + 'px, ' + (splitX + rdx) + 'px)';
 
             compareSliderEl.style.left = splitX + 'px';
         };

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -88,8 +88,7 @@
         color: '#ff8f00',
         weight: 3,
         opacity: 0.95,
-        fillColor: '#ff8f00',
-        fillOpacity: 0.08
+        fill: false
     };
 
     // ── Register a Planetary Computer mosaic for a given NAIP year ──

--- a/blog-interactive/js/app.js
+++ b/blog-interactive/js/app.js
@@ -483,11 +483,31 @@
             });
         });
 
-        // Once all mosaics are registered, add layer control
+        // Once all mosaics are registered, add layer control and re-apply
+        // the current step's layers in case the user scrolled to a NAIP step
+        // before registration completed.
         Promise.all(promises).then(function () {
             refreshLayerControl();
-
             console.log('All NAIP mosaic layers ready');
+
+            // Re-apply layers for the active step if it uses NAIP
+            var activeStepEl = document.querySelector('.step.is-active');
+            if (activeStepEl) {
+                var layerStr = activeStepEl.getAttribute('data-layers');
+                if (layerStr && layerStr.indexOf('naip-') !== -1) {
+                    var layerNames = layerStr.split(',').map(function (n) { return n.trim(); });
+                    setVisibleLayers(layerNames);
+                    // Re-enable compare if needed
+                    var isCompare = activeStepEl.getAttribute('data-compare') === 'true';
+                    if (isCompare) {
+                        var compareLeft = activeStepEl.getAttribute('data-compare-left') || 'naip-2014';
+                        var compareRight = activeStepEl.getAttribute('data-compare-right') || 'naip-2018';
+                        var compareLeftLabel = activeStepEl.getAttribute('data-compare-left-label');
+                        var compareRightLabel = activeStepEl.getAttribute('data-compare-right-label');
+                        enableCompare(compareLeft, compareRight, compareLeftLabel, compareRightLabel);
+                    }
+                }
+            }
         });
     }
 


### PR DESCRIPTION
## Problem

At tablet and narrow desktop widths (roughly 900–1200px), the side-by-side scrollytelling layout has text content overflowing or visually crowding into the map. There was no intermediate breakpoint between full desktop (>1200px) and the 900px stacked layout.

## Changes

**New 1200px breakpoint** — tightens the side-by-side layout before stacking:
- Shifts from 55%/45% to 50%/50% map/story split
- Reduces `.step-content` padding and body font sizes so text fits cleanly in the narrower column

**Improved 900px breakpoint** — stacked layout now also scales media panels:
- `.environment-media-figure`, `.after-ban-media-figure`, `.conclusion-media-figure` fill width at 100%
- Images and slideshows constrained to ~42vh so they don't dominate the stacked view

**New 600px breakpoint** — mobile polish:
- Tightens header typography (`.site-title`, `.site-subtitle`, `.byline`)
- Reduces step padding and font sizes for small phones

**CSS cache-bust**: style.css bumped to v=9