### PR TITLE
fix: use 100dvh on site-header for mobile browser chrome

### DIFF
--- a/blog-interactive/css/style.css
+++ b/blog-interactive/css/style.css
@@ -34,7 +34,7 @@ a:hover {
 /* ===== Header ===== */
 .site-header {
     position: relative;
-    min-height: 100vh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
min-height: 100vh on .site-header doesn't account for iOS Safari / Chrome address bar height, causing the header to overflow the visible viewport on mobile.

Switching to 100dvh (dynamic viewport height) sizes the header to the actual visible area. Well-supported across all modern mobile browsers.

Fixes #29