### PR TITLE
feat: add utteranc.es comment system to interactive blog

### DIFF
--- a/blog-interactive/css/style.css
+++ b/blog-interactive/css/style.css
@@ -809,3 +809,46 @@ a:hover {
         font-size: 0.8rem;
     }
 }
+
+/* ===== Comments (utteranc.es) ===== */
+
+.comments-section {
+    background: #0f0f0f;
+    border-top: 1px solid #2a2a2a;
+    padding: 3rem 1.5rem 4rem;
+}
+
+.comments-container {
+    max-width: 760px;
+    margin: 0 auto;
+}
+
+.comments-heading {
+    font-family: 'Merriweather', serif;
+    font-size: 1.4rem;
+    font-weight: 400;
+    color: #f4f1ea;
+    margin: 0 0 0.5rem;
+}
+
+.comments-note {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.82rem;
+    color: #888;
+    margin: 0 0 1.75rem;
+}
+
+.comments-note a {
+    color: #aaa;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.comments-note a:hover {
+    color: #f4f1ea;
+}
+
+/* Constrain the utteranc.es iframe width */
+.utterances {
+    max-width: 100% !important;
+}

--- a/blog-interactive/index.html
+++ b/blog-interactive/index.html
@@ -17,7 +17,7 @@
     <script src="https://unpkg.com/intersection-observer@0.12.2/intersection-observer.js"></script>
 
     <!-- Custom styles -->
-    <link rel="stylesheet" href="css/style.css?v=9" />
+    <link rel="stylesheet" href="css/style.css?v=10" />
 
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -195,6 +195,21 @@
             </div><!-- .story -->
         </section><!-- #scrolly -->
     </main>
+
+    <!-- ===== COMMENTS ===== -->
+    <section class="comments-section">
+        <div class="comments-container">
+            <h2 class="comments-heading">Discussion</h2>
+            <p class="comments-note">Comments are powered by <a href="https://utteranc.es" target="_blank" rel="noopener">utteranc.es</a> and stored as GitHub Issues. A GitHub account is required to comment.</p>
+            <script src="https://utteranc.es/client.js"
+                    repo="wxmiked/cannabis-deforestation"
+                    issue-term="pathname"
+                    theme="github-dark"
+                    crossorigin="anonymous"
+                    async>
+            </script>
+        </div>
+    </section>
 
     <!-- ===== FOOTER ===== -->
     <footer class="site-footer">


### PR DESCRIPTION
Closes #20

Integrates utteranc.es as a zero-infrastructure comment backend. Comments are stored as GitHub Issues in this repo.

**Config:**
- `issue-term: pathname` — each URL path maps to its own issue thread
- `theme: github-dark` — matches site dark palette
- `repo: wxmiked/cannabis-deforestation`

Added a `.comments-section` block between `<main>` and `<footer>` with Merriweather/Inter typography to match existing site style. Includes a `.utterances` max-width override so the iframe doesn't break the layout.