### PR TITLE
Link grand jury report in blog

### DIFF
--- a/blog-interactive/index.html
+++ b/blog-interactive/index.html
@@ -127,7 +127,7 @@
                             <li>The environmental damage — deforestation, soil disturbance, altered drainage — remained visible</li>
                         </ul>
                         <p>Today, even where some of these scars are partially hidden by new vegetation, the underlying disturbance remains.</p>
-                        <p>By 2022, only <strong>65 licensed cultivation sites</strong> remained, while unpermitted activity continued at a wider scale, as documented in the <strong>2023 Calaveras County Civil Grand Jury Report</strong>.</p>
+                        <p>By 2022, only <strong>65 licensed cultivation sites</strong> remained, while unpermitted activity continued at a wider scale, as documented in the <a href="https://grandjury.calaverasgov.us/Portals/grandjury/Documents/Reports/Individual%20Reports/2022%20-%202023/Calaveras%20Cannabis%20Dis-Jointed.pdf?ver=2tAuT7IFwdYCsOE27i7uKg%3d%3d" target="_blank" rel="noopener"><strong>2023 Calaveras County Civil Grand Jury Report</strong></a>.</p>
                     </div></div>
                 </div>
 
@@ -155,7 +155,7 @@
                 <div class="step" data-step="environment" data-center="38.19,-120.55" data-zoom="11" data-layers="parcels">
                     <div class="step-content-wrapper"><div class="step-content">
                         <h2>Environmental Impact</h2>
-                        <p>According to the <strong>2023 Calaveras County Civil Grand Jury Report</strong>, illegal cannabis cultivation has significantly impacted the environment:</p>
+                        <p>According to the <a href="https://grandjury.calaverasgov.us/Portals/grandjury/Documents/Reports/Individual%20Reports/2022%20-%202023/Calaveras%20Cannabis%20Dis-Jointed.pdf?ver=2tAuT7IFwdYCsOE27i7uKg%3d%3d" target="_blank" rel="noopener"><strong>2023 Calaveras County Civil Grand Jury Report</strong></a>, illegal cannabis cultivation has significantly impacted the environment:</p>
                         <ul>
                             <li><strong>Deforestation</strong> of native oak woodland and mixed conifer forest</li>
                             <li><strong>Soil contamination</strong> from pesticides and fertilizers</li>

--- a/blog-interactive/index.html
+++ b/blog-interactive/index.html
@@ -127,7 +127,7 @@
                             <li>The environmental damage — deforestation, soil disturbance, altered drainage — remained visible</li>
                         </ul>
                         <p>Today, even where some of these scars are partially hidden by new vegetation, the underlying disturbance remains.</p>
-                        <p>By 2022, only <strong>65 licensed cultivation sites</strong> remained, while unpermitted activity continued at a wider scale, as documented in the <a href="https://grandjury.calaverasgov.us/Portals/grandjury/Documents/Reports/Individual%20Reports/2022%20-%202023/Calaveras%20Cannabis%20Dis-Jointed.pdf?ver=2tAuT7IFwdYCsOE27i7uKg%3d%3d" target="_blank" rel="noopener"><strong>2023 Calaveras County Civil Grand Jury Report</strong></a>.</p>
+                        <p>By 2022, only <strong>65 licensed cultivation sites</strong> remained, while unpermitted activity continued at a wider scale, as documented in the <a href="https://grandjury.calaverasgov.us/Portals/grandjury/Documents/Reports/Individual%20Reports/2022%20-%202023/Calaveras%20Cannabis%20Dis-Jointed.pdf?ver=2tAuT7IFwdYCsOE27i7uKg%3d%3d" target="_blank" rel="noopener">2023 Calaveras County Civil Grand Jury Report</a>.</p>
                     </div></div>
                 </div>
 
@@ -155,7 +155,7 @@
                 <div class="step" data-step="environment" data-center="38.19,-120.55" data-zoom="11" data-layers="parcels">
                     <div class="step-content-wrapper"><div class="step-content">
                         <h2>Environmental Impact</h2>
-                        <p>According to the <a href="https://grandjury.calaverasgov.us/Portals/grandjury/Documents/Reports/Individual%20Reports/2022%20-%202023/Calaveras%20Cannabis%20Dis-Jointed.pdf?ver=2tAuT7IFwdYCsOE27i7uKg%3d%3d" target="_blank" rel="noopener"><strong>2023 Calaveras County Civil Grand Jury Report</strong></a>, illegal cannabis cultivation has significantly impacted the environment:</p>
+                        <p>According to the <a href="https://grandjury.calaverasgov.us/Portals/grandjury/Documents/Reports/Individual%20Reports/2022%20-%202023/Calaveras%20Cannabis%20Dis-Jointed.pdf?ver=2tAuT7IFwdYCsOE27i7uKg%3d%3d" target="_blank" rel="noopener">2023 Calaveras County Civil Grand Jury Report</a>, illegal cannabis cultivation has significantly impacted the environment:</p>
                         <ul>
                             <li><strong>Deforestation</strong> of native oak woodland and mixed conifer forest</li>
                             <li><strong>Soil contamination</strong> from pesticides and fertilizers</li>


### PR DESCRIPTION
Both references to the 2023 Calaveras County Civil Grand Jury Report in `blog-interactive/index.html` now link directly to the official county PDF ([Calaveras Cannabis Dis-Jointed](https://grandjury.calaverasgov.us/Portals/grandjury/Documents/Reports/Individual%20Reports/2022%20-%202023/Calaveras%20Cannabis%20Dis-Jointed.pdf?ver=2tAuT7IFwdYCsOE27i7uKg%3d%3d)).